### PR TITLE
Add missing models

### DIFF
--- a/server/models/download.sh
+++ b/server/models/download.sh
@@ -46,6 +46,13 @@ lambdalabs/sd-image-variations-diffusers
 facebook/timesformer-base-finetuned-k400
 facebook/maskformer-swin-base-coco
 Intel/dpt-hybrid-midas
+lllyasviel/sd-controlnet-canny
+lllyasviel/sd-controlnet-depth
+lllyasviel/sd-controlnet-hed
+lllyasviel/sd-controlnet-mlsd
+lllyasviel/sd-controlnet-openpose
+lllyasviel/sd-controlnet-scribble
+lllyasviel/sd-controlnet-seg
 "
 
 # CURRENT_DIR=$(cd `dirname $0`; pwd)


### PR DESCRIPTION
After following instructions, setting up conda and then running `python models_server.py` I recevied such errors

```
Traceback (most recent call last):
  File "/root/anaconda3/envs/jarvis/lib/python3.8/site-packages/diffusers/configuration_utils.py", line 344, in load_config
    config_file = hf_hub_download(
  File "/root/anaconda3/envs/jarvis/lib/python3.8/site-packages/huggingface_hub/utils/_validators.py", line 112, in _inner_fn
    validate_repo_id(arg_value)
  File "/root/anaconda3/envs/jarvis/lib/python3.8/site-packages/huggingface_hub/utils/_validators.py", line 160, in validate_repo_id
    raise HFValidationError(
huggingface_hub.utils._validators.HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': 'models/lllyasviel/sd-controlnet-canny'. Use `repo_type` argument if needed.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "models_server.py", line 338, in <module>
    pipes = load_pipes(local_models)
  File "models_server.py", line 267, in load_pipes
    controlnet = ControlNetModel.from_pretrained(f"{local_fold}/lllyasviel/sd-controlnet-canny", torch_dtype=torch.float16)
  File "/root/anaconda3/envs/jarvis/lib/python3.8/site-packages/diffusers/models/modeling_utils.py", line 472, in from_pretrained
    config, unused_kwargs, commit_hash = cls.load_config(
  File "/root/anaconda3/envs/jarvis/lib/python3.8/site-packages/diffusers/configuration_utils.py", line 380, in load_config
    raise EnvironmentError(
OSError: We couldn't connect to 'https://huggingface.co' to load this model, couldn't find it in the cached files and it looks like models/lllyasviel/sd-controlnet-canny is not the path to a directory containing a config.json file.
Checkout your internet connection or see how to run the library in offline mode at 'https://huggingface.co/docs/diffusers/installation#offline-mode'.
```

Added them to download list. Here are the added models 

```
lllyasviel/sd-controlnet-canny
lllyasviel/sd-controlnet-depth
lllyasviel/sd-controlnet-hed
lllyasviel/sd-controlnet-mlsd
lllyasviel/sd-controlnet-openpose
lllyasviel/sd-controlnet-scribble
lllyasviel/sd-controlnet-seg
```
