### PR TITLE
Add `CITATION.cff` file to make it easy to cite JARVIS

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you find this work useful in your method, you can cite the paper as below."
+title: HuggingGPT: Solving AI Tasks with ChatGPT and its Friends in HuggingFace
+authors:
+  - family-names: Shen
+    given-names: Yongliang
+  - family-names: Song
+    given-names: Kaitao
+  - family-names: Tan
+    given-names: Xu
+  - family-names: Li
+    given-names: Dongsheng
+  - family-names: Lu
+    given-names: Weiming
+  - family-names: Zhuang
+    given-names: Yueting
+license: MIT
+status: preprint
+date-released: 2023-03-30
+url: https://arxiv.org/abs/2303.17580


### PR DESCRIPTION
This commit adds a `CITATION.cff` file to make it easy to cite JARVIS in different styles and formats, such as APA and BibTeX.

See [About CITATION files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) for more info.