### PR TITLE
General improvements to `CONTRIBUTING.MD`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,11 @@ To contribute to this GitHub project, you can follow these steps:
 
 1. Fork the repository you want to contribute to by clicking the "Fork" button on the project page.
 
-2. Clone the repository to your local machine using the following command (make sure to insert your Github username in the command)
+2. Clone the repository to your local machine and enter the newly created repo using the following commands:
 
 ```
 git clone https://github.com/YOUR-GITHUB-USERNAME/JARVIS
+cd JARVIS
 ```
 3. Create a new branch for your changes using the following command:
 
@@ -14,7 +15,6 @@ git clone https://github.com/YOUR-GITHUB-USERNAME/JARVIS
 git checkout -b "branch-name"
 ```
 4. Make your changes to the code or documentation.
-- Example: Improve User Interface or Add Documentation.
 
 5. Add the changes to the staging area using the following command:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ git push origin branch-name
 
 ```
 git fetch upstream
-git checkout master
-git merge upstream/master
+git checkout main
+git merge upstream/main
 ```
 Finally, delete the branch you created with the following command:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To contribute to this GitHub project, you can follow these steps:
 2. Clone the repository to your local machine using the following command:
 
 ```
-git clonehttps://github.com/microsoft/JARVIS
+git clone https://github.com/microsoft/JARVIS
 ```
 3. Create a new branch for your changes using the following command:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,10 @@ To contribute to this GitHub project, you can follow these steps:
 
 1. Fork the repository you want to contribute to by clicking the "Fork" button on the project page.
 
-2. Clone the repository to your local machine using the following command:
+2. Clone the repository to your local machine using the following command (make sure to insert your Github username in the command)
 
 ```
-git clone https://github.com/microsoft/JARVIS
+git clone https://github.com/YOUR-GITHUB-USERNAME/JARVIS
 ```
 3. Create a new branch for your changes using the following command:
 


### PR DESCRIPTION
This PR includes minor improvements to the repo's contribution guide:

- Fixes a typo where there was a missing whitespace between the `clone` and URL of the 2nd step
- Replaces the username of the cloned repo from `microsoft` to user's GitHub account
- Adds the step of entering the cloned repo locally with `cd JARVIS`