### PR TITLE
fix cand_models_info

### DIFF
--- a/server/awesome_chat.py
+++ b/server/awesome_chat.py
@@ -816,8 +816,8 @@ def run_task(input, command, results, openaikey = None):
                     ),
                     "likes": model.get("likes"),
                     "description": model.get("description", "")[:config["max_description_length"]],
-                    "language": model.get("language"),
-                    "tags": model.get("tags"),
+                    "language": model.get("meta").get("language"),
+                    "tags": model.get("meta").get("tags"),
                 }
                 for model in candidates
                 if model["id"] in all_avaliable_model_ids


### PR DESCRIPTION
The previous request was returning `None` for both `.get("tags")` and  `.get("language")`.
the structure of `data/p0_models.jsonl` is the following 
```
{ ..., "meta": {"language": " ", "tags": []}, ...}
```
fixed this by calling
```python 
.get("meta").get("language")
.get("meta").get("tags"),
```
instead