### PR TITLE
Fix Console Error and add setting icon button tips

### DIFF
--- a/web/src/api/chatgpt.ts
+++ b/web/src/api/chatgpt.ts
@@ -32,7 +32,7 @@ export async function chatgpt(messageList: CleanChatMessage[], apiKey: string, d
   } catch (error: any) {
     return {
       status: "error",
-      message: error.response.data.error.message,
+      message: "Unknown Error, please retry.",
     };
   }
 }

--- a/web/src/views/home.vue
+++ b/web/src/views/home.vue
@@ -320,7 +320,7 @@ watch(messageListMM, () => nextTick(() => {
         </div>
         
         <div class="text-sm cursor-pointer w-1/4 flex flex-row justify-end" @click="dev || clickConfig()" @dblclick="switchChatGPT()">
-            <img src="@/assets/setting.svg" class="w-7 block"/>
+            <img src="@/assets/setting.svg" class="w-7 block" title="click to switch to configuration OpenAI key or double click to switch HuggingGPT and ChatGPT"/>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fix the Console error when the network error occurs, prompting that `Cannot read properties of undefined (reading 'data')`, undefined code `data` in `error.response` and add a setting icon button prompt.