### PR TITLE
Update home.vue

### DIFF
--- a/web/src/views/home.vue
+++ b/web/src/views/home.vue
@@ -103,7 +103,7 @@ const messageListMM = computed(() => {
         start += seq_added_accum
         end += seq_added_accum
         const replace_str = `<span class="inline-flex items-baseline">
-          <a class="inline-flex text-sky-800 font-bold items-baseline" target="_blank" href="${image_urls[j].startsWith("http")?image_urls[j]:""+image_urls[j]}">
+          <a class="inline-flex text-sky-800 font-bold items-baseline" target="_blank" href="${image_urls[j].startsWith("http")?image_urls[j]:BASE_URL+image_urls[j]}">
               <img src="${image_urls[j].startsWith("http")?image_urls[j]:BASE_URL+image_urls[j]}" alt="" class="inline-flex self-center w-5 h-5 rounded-full mx-1" />
               <span class="mx-1">[Image]</span>
           </a>


### PR DESCRIPTION
fix：生产的回答中如果有图片。通过a标签点击，发现跳转的是web服务器端口下的地址，很明显生成的图片是在后端服务的端口地址。

和下面的audio、video的写法保持一致，加上一个BASE_URL