### PR TITLE
Dependabot alert to update flask version

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,7 +5,7 @@ tiktoken==0.3.3
 pydub==0.25.1
 espnet==202301
 espnet_model_zoo==0.1.7
-flask==2.2.3
+flask==2.3.2
 flask_cors==3.0.10
 waitress==2.1.2
 datasets==2.11.0


### PR DESCRIPTION
This PR simply bumps flask version from 2.2.3 to 2.3.2 in /server.

Dependabot caught this in my fork, so I'm submitting it upstream.